### PR TITLE
fix(CentraProvider): restore previous selection if present

### DIFF
--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -162,6 +162,12 @@ export function CentraProvider(props: ProviderProps) {
 
   const init = React.useCallback<NonNullable<ContextMethods['init']>>(async (selectionData) => {
     let response
+
+    const clientToken = window.localStorage.getItem('checkoutToken')
+    if (clientToken) {
+      apiClient.headers.set('api-token', clientToken)
+    }
+
     if (!selectionData) {
       response = (await apiClient.request('GET', 'selection')) as Centra.SelectionResponseExtended
     } else {
@@ -171,13 +177,9 @@ export function CentraProvider(props: ProviderProps) {
     if (response && response.selection) {
       setSelection(response)
 
-      const clientToken = window.localStorage.getItem('checkoutToken')
-
       if (response.token && response.token !== clientToken) {
         apiClient.headers.set('api-token', response.token)
         window.localStorage.setItem('checkoutToken', response.token)
-      } else if (clientToken) {
-        apiClient.headers.set('api-token', clientToken)
       }
     }
   }, [])


### PR DESCRIPTION
Fixes an issue where the selection is reset after refreshing the page when running the app in development.