### PR TITLE
feat(CentraProvider): add 'updateCustomer' method

### DIFF
--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -75,6 +75,7 @@ export interface ContextMethods {
     country: string,
     data: { language: string },
   ): Promise<Centra.SelectionResponseExtended>
+  updateCustomer?(data: Record<string, unknown>): Promise<Centra.SelectionResponseExtended>
   updateCustomerAddress?(data: Record<string, unknown>): Promise<Centra.SelectionResponseExtended>
   updateCustomerEmail?(email: string): Promise<Centra.SelectionResponseExtended>
   updateCustomerPassword?(
@@ -331,6 +332,11 @@ export function CentraProvider(props: ProviderProps) {
     [selectionApiCall],
   )
 
+  const updateCustomer = React.useCallback<NonNullable<ContextMethods['updateCustomer']>>(
+    (data) => selectionApiCall(apiClient.request('PUT', `customer/update`, data)),
+    [selectionApiCall],
+  )
+
   const updateCustomerAddress = React.useCallback<
     NonNullable<ContextMethods['updateCustomerAddress']>
   >((data) => selectionApiCall(apiClient.request('PUT', `address`, data)), [selectionApiCall])
@@ -399,6 +405,7 @@ export function CentraProvider(props: ProviderProps) {
       updateCartItemQuantity,
       updateCartItemSize,
       updateCountry,
+      updateCustomer,
       updateCustomerAddress,
       updateCustomerEmail,
       updateCustomerPassword,
@@ -424,6 +431,7 @@ export function CentraProvider(props: ProviderProps) {
       updateCartItemQuantity,
       updateCartItemSize,
       updateCountry,
+      updateCustomer,
       updateCustomerAddress,
       updateCustomerEmail,
       updateCustomerPassword,


### PR DESCRIPTION
There is currently no way to unsubscribe a user from the newsletter. As far as I can tell this is the only [endpoint](https://docs.centra.com/swagger-ui/?api=CheckoutAPI#/6.%20customer%20handling/put_customer_update) that allows this.

This introduces some redundancy with 'updateCustomerAddress' and 'updateCustomerEmail'. Perhaps it would make more sense if there was a method solely responsible for updating the newsletter field value.

It might be that this scenario doesn't happen often enough to warrant its own method. Feel free to close this PR if that is indeed the case.