### PR TITLE
fix(PaymentEmbed): add 'additionalPaymentProps'

### DIFF
--- a/packages/react-centra-checkout/src/PaymentEmbed/index.tsx
+++ b/packages/react-centra-checkout/src/PaymentEmbed/index.tsx
@@ -4,7 +4,7 @@ import { useCentraSelection, useCentraHandlers } from '../Context'
 import PaymentEmbedHtml from './partials/PaymentEmbedHtml'
 
 export interface PaymentEmbedProps {
-  additionalPaymentProps?: object
+  additionalPaymentProps?: Record<string, unknown>
   onSuccess?(paymentResult: Centra.PaymentResponse): void
   onError?(error: Record<string, string>): void
 }

--- a/packages/react-centra-checkout/src/PaymentEmbed/index.tsx
+++ b/packages/react-centra-checkout/src/PaymentEmbed/index.tsx
@@ -4,9 +4,7 @@ import { useCentraSelection, useCentraHandlers } from '../Context'
 import PaymentEmbedHtml from './partials/PaymentEmbedHtml'
 
 export interface PaymentEmbedProps {
-  paymentReturnPage: string
-  paymentFailedPage: string
-  termsAndConditions: boolean
+  additionalPaymentProps?: object
   onSuccess?(paymentResult: Centra.PaymentResponse): void
   onError?(error: Record<string, string>): void
 }
@@ -14,7 +12,7 @@ export interface PaymentEmbedProps {
 /** This component handles rendering of payment widgets such as Klarna Checkout and Adyen drop-in, if you submit payments yourself directly,
 you should simply call the submitPayment method of the context instead */
 function PaymentEmbed(props: PaymentEmbedProps): React.ReactElement | null {
-  const { paymentReturnPage, paymentFailedPage, termsAndConditions, onError, onSuccess } = props
+  const { additionalPaymentProps = {}, onError, onSuccess } = props
 
   const [paymentResult, setPaymentResult] = React.useState<Centra.PaymentResponse | null>(null)
   const [formHtml, setFormHtml] = React.useState<string | null>(null)
@@ -32,7 +30,6 @@ function PaymentEmbed(props: PaymentEmbedProps): React.ReactElement | null {
     if (
       selection &&
       paymentMethod &&
-      termsAndConditions &&
       (paymentMethod.providesCustomerAddressAfterPayment || paymentMethod.supportsInitiateOnly)
     ) {
       const { address, shippingAddress } = selection
@@ -42,7 +39,7 @@ function PaymentEmbed(props: PaymentEmbedProps): React.ReactElement | null {
         paymentInitiateOnly: paymentMethod.supportsInitiateOnly,
         paymentMethod: paymentMethodId,
         shippingAddress,
-        termsAndConditions,
+        ...additionalPaymentProps,
       })
         .then((result) => {
           setPaymentResult(result)
@@ -50,12 +47,10 @@ function PaymentEmbed(props: PaymentEmbedProps): React.ReactElement | null {
         .catch(console.error)
     }
   }, [
-    paymentFailedPage,
+    additionalPaymentProps,
     paymentMethod,
     paymentMethodId,
-    paymentReturnPage,
     selection,
-    termsAndConditions,
     submitPayment,
   ])
 

--- a/packages/react-centra-checkout/src/PaymentEmbed/index.tsx
+++ b/packages/react-centra-checkout/src/PaymentEmbed/index.tsx
@@ -6,6 +6,7 @@ import PaymentEmbedHtml from './partials/PaymentEmbedHtml'
 export interface PaymentEmbedProps {
   paymentReturnPage: string
   paymentFailedPage: string
+  termsAndConditions: boolean
   onSuccess?(paymentResult: Centra.PaymentResponse): void
   onError?(error: Record<string, string>): void
 }
@@ -13,7 +14,7 @@ export interface PaymentEmbedProps {
 /** This component handles rendering of payment widgets such as Klarna Checkout and Adyen drop-in, if you submit payments yourself directly,
 you should simply call the submitPayment method of the context instead */
 function PaymentEmbed(props: PaymentEmbedProps): React.ReactElement | null {
-  const { paymentReturnPage, paymentFailedPage, onError, onSuccess } = props
+  const { paymentReturnPage, paymentFailedPage, termsAndConditions, onError, onSuccess } = props
 
   const [paymentResult, setPaymentResult] = React.useState<Centra.PaymentResponse | null>(null)
   const [formHtml, setFormHtml] = React.useState<string | null>(null)
@@ -31,6 +32,7 @@ function PaymentEmbed(props: PaymentEmbedProps): React.ReactElement | null {
     if (
       selection &&
       paymentMethod &&
+      termsAndConditions &&
       (paymentMethod.providesCustomerAddressAfterPayment || paymentMethod.supportsInitiateOnly)
     ) {
       const { address, shippingAddress } = selection
@@ -40,6 +42,7 @@ function PaymentEmbed(props: PaymentEmbedProps): React.ReactElement | null {
         paymentInitiateOnly: paymentMethod.supportsInitiateOnly,
         paymentMethod: paymentMethodId,
         shippingAddress,
+        termsAndConditions,
       })
         .then((result) => {
           setPaymentResult(result)
@@ -52,6 +55,7 @@ function PaymentEmbed(props: PaymentEmbedProps): React.ReactElement | null {
     paymentMethodId,
     paymentReturnPage,
     selection,
+    termsAndConditions,
     submitPayment,
   ])
 


### PR DESCRIPTION
Not sure if this is the best solution but this field seems to be required when making a [/payment](https://docs.centra.com/swagger-ui/?api=CheckoutAPI#/4.%20selection%20handling%2C%20checkout%20flow/post_payment) request.