### PR TITLE
feat: output yarn installation progress to terminal

### DIFF
--- a/packages/create-app/createApp.js
+++ b/packages/create-app/createApp.js
@@ -77,7 +77,7 @@ async function createApp() {
   process.chdir(projectPath)
 
   console.log(`\nInstalling dependencies. This could take a few minutes.\n`)
-  spawn.sync('yarnpkg', ['install'])
+  spawn.sync('yarnpkg', ['install'], { stdio: 'inherit' })
 
   await updatePackageFile()
 


### PR DESCRIPTION
This enables the user to see the yarn installation progress while running the npx script

fix #33
