### PR TITLE
feat(CentraContext): add 'resetSelection' method

### DIFF
--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -334,6 +334,7 @@ export function CentraProvider(props: ProviderProps) {
     [selectionApiCall],
   )
 
+  /** Resets the selection. Useful if you need a fresh `api-token` (when a user exits a campaign site, for example). */
   const resetSelection = React.useCallback<NonNullable<ContextMethods['resetSelection']>>(() => {
     apiClient.headers.delete('api-token')
     localStorage.removeItem('checkoutToken')

--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -60,6 +60,7 @@ export interface ContextMethods {
     id: string,
     newPassword: string,
   ): Promise<Centra.SelectionResponseExtended>
+  resetSelection?(): void
   /**
     @param linkUri - URI of the password reset page. Should not be a full url e.g. `account/password-reset`. Domain is set in Centra.
   */
@@ -333,6 +334,12 @@ export function CentraProvider(props: ProviderProps) {
     [selectionApiCall],
   )
 
+  const resetSelection = React.useCallback<NonNullable<ContextMethods['resetSelection']>>(() => {
+    apiClient.headers.delete('api-token')
+    localStorage.removeItem('checkoutToken')
+    init()
+  }, [init])
+
   const sendCustomerResetPasswordEmail = React.useCallback<
     NonNullable<ContextMethods['sendCustomerResetPasswordEmail']>
   >(
@@ -414,6 +421,7 @@ export function CentraProvider(props: ProviderProps) {
       removeCartItem,
       removeVoucher,
       resetCustomerPassword,
+      resetSelection,
       sendCustomerResetPasswordEmail,
       submitPayment,
       updateCartItemQuantity,
@@ -442,6 +450,7 @@ export function CentraProvider(props: ProviderProps) {
       removeCartItem,
       removeVoucher,
       resetCustomerPassword,
+      resetSelection,
       sendCustomerResetPasswordEmail,
       submitPayment,
       updateCartItemQuantity,


### PR DESCRIPTION
This attempts to solve an issue I'm having with resetting the selection when a user exits a campaign site (notably the users market). This is because the context methods use a static instance of the `ApiClient` and calling the `init` method doesn't reinitialize the necessary header.

This felt like the most flexible/reusable solution although it would also be possible to handle this in the `init` method. Either by adding an optional `reset` argument or just updating this part:

```
const clientToken = window.localStorage.getItem('checkoutToken')

if (clientToken) {
  apiClient.headers.set('api-token', clientToken)
} else {
  apiClient.headers.delete('api-token')
}
```

Although this would still require us to clear the `checkoutToken` from storage before calling `init`, which doesn't feel very intuitive.

I think there's also a case to be made for always reinitializing the `ApiClient` every time `init` is called.