### PR TITLE
react-centra-checkout - Use cookie instead of localStorage for session token

### DIFF
--- a/packages/react-centra-checkout/package.json
+++ b/packages/react-centra-checkout/package.json
@@ -46,5 +46,9 @@
   },
   "engines": {
     "node": ">=12.0.0"
+  },
+  "dependencies": {
+    "@types/js-cookie": "^3.0.1",
+    "js-cookie": "^3.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3980,6 +3980,11 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
+"@types/js-cookie@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.1.tgz#04aa743e2e0a85a22ee9aa61f6591a8bc19b5d68"
+  integrity sha512-7wg/8gfHltklehP+oyJnZrz9XBuX5ZPP4zB6UsI84utdlkRYLnOm2HfpLXazTwZA+fpGn0ir8tGNgVnMEleBGQ==
+
 "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
@@ -10023,6 +10028,11 @@ jest@^27.4.3:
     "@jest/core" "^27.4.7"
     import-local "^3.0.2"
     jest-cli "^27.4.7"
+
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 js-string-escape@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This pull request changes the storage of the Centra checkout api token to a cookie instead of localStorage. This has a number of benefits:

- With a cookie, it's possible to read the token both server and client side. This means we can, for example, fetch the users selection directly on the server on the checkout and receipt pages, displaying a complete page instead of serving an empty page that is populated client side.
- Makes it possible to read the users session token in a Next.js middleware which opens up possibilities to do rewrites / redirects etc based on the token
- When searching for this topic, the general consensus seems to be storing session tokens in localStorage is not the way to go. Security is one of the reasons. While we will still have the same security concerns regarding XSS since this PR does not use a Http only cookie, this at least enables us to move in the right direction in that regard. If security at some point becomes an issue, we can move to using a Http only cookie and have some small proxy inbetween the Centra checkout api which reads the cookie and sends it as a header.

The only drawback is we introduce a small (780B) dependency on js-cookie to read cookies.

Along with the cookie functionality is a few small tweaks:
- `disableInitialSelection` renamed to `disableInit` since it doesn't actually disable the initial selection (which is an empty selection), but rather disables the init function from running
- added `initialSelection` which allows to pass an initial selection object to the Context. Useful if you for example fetch the selection server side