### PR TITLE
feat(ApiClient): add fetch options

### DIFF
--- a/packages/react-centra-checkout/src/ApiClient/index.ts
+++ b/packages/react-centra-checkout/src/ApiClient/index.ts
@@ -1,6 +1,8 @@
 class ApiClient {
   baseUrl: string
 
+  options: RequestInit
+
   static default: ApiClient
 
   headers: Headers = new Headers({
@@ -8,8 +10,9 @@ class ApiClient {
     'Content-Type': 'application/json',
   })
 
-  constructor(baseUrl = '') {
+  constructor(baseUrl = '', options: RequestInit = {}) {
     this.baseUrl = baseUrl
+    this.options = options
   }
 
   async request(method: string, endpoint: string, data: Record<string, unknown> = {}) {
@@ -18,6 +21,7 @@ class ApiClient {
       mode: 'cors',
       method,
       body: ['POST', 'PUT'].includes(method) ? JSON.stringify(data) : undefined,
+      ...this.options,
     })
 
     const json = await response.json()


### PR DESCRIPTION
Adds ability to change options on the api client. This is useful for example on Vercel edge functions where `mode: 'cors'` is not supported.