### PR TITLE
feat(Context): add 'addGiftCertficate'

### DIFF
--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -18,6 +18,10 @@ export interface ContextMethods {
     @param item - The Centra item id
   */
   addItem?(item: string, quantity?: number): Promise<Centra.SelectionResponseExtended>
+  /**
+    @param giftCertificate - The `giftCertificate` value of the gift certificate to add
+  */
+  addGiftCertificate?(giftCertificate: string): Promise<Centra.SelectionResponseExtended>
   addNewsletterSubscription?(
     data: Record<string, unknown>,
   ): Promise<Centra.SelectionResponseExtended>
@@ -195,6 +199,12 @@ export function CentraProvider(props: ProviderProps) {
   const addItem = React.useCallback<NonNullable<ContextMethods['addItem']>>(
     (item, quantity = 1) =>
       selectionApiCall(apiClient.request('POST', `items/${item}/quantity/${quantity}`)),
+    [selectionApiCall],
+  )
+
+  const addGiftCertificate = React.useCallback<NonNullable<ContextMethods['addGiftCertificate']>>(
+    (giftCertificate) =>
+      selectionApiCall(apiClient.request('POST', `items/gift-certificates/${giftCertificate}`)),
     [selectionApiCall],
   )
 
@@ -411,6 +421,7 @@ export function CentraProvider(props: ProviderProps) {
   const centraHandlersContext = React.useMemo<ContextMethods>(
     (): ContextMethods => ({
       addItem,
+      addGiftCertificate,
       addNewsletterSubscription,
       addVoucher,
       decreaseCartItem,
@@ -440,6 +451,7 @@ export function CentraProvider(props: ProviderProps) {
     }),
     [
       addItem,
+      addGiftCertificate,
       addNewsletterSubscription,
       addVoucher,
       decreaseCartItem,


### PR DESCRIPTION
- [x] Create 'addGiftCertificate' hook
- [ ] Determine if/how we should account for the differentiating structure in `selection.items`

In regards of the [`PUT /selections`](https://docs.centra.com/swagger-ui/?api=CheckoutAPI#/3.%20selection%20handling%2C%20modify%20selection/put_selection) the gift certificates are currently a bit weird in Centra.
As the referenced documentation states, a `selection.items[]` object should have the following structure: 

```json

[
    {
	...
        "product": {
		...
            "product": "69",
            "name": "Force Advanced softshell jacket Hi-vis orange",
            "uri": "force-advanced-softshell-jacket-1002176",
            "sku": "100217655",
            "productSku": "1002176",
            "brand": "2",
            "brandName": "Seeland",
            "brandUri": "seeland",
            "collection": "3",
            "collectionName": "202103",
            "collectionUri": "202103",
            "variantName": "Hi-vis orange",
		...
        }
    }
]
```

while this is the following structure of `selection.items[]` objects, when there are only a gift certificate present:

```json
{
	...
    "product": "gift-7",
	...
}
```

Then, to ensure a complete customer journey for gift certificates, when need either to format / convert the gift certificate to the ordinary (for an ordinary product) data structure or customize the user journey.
