### PR TITLE
fix(context): set tokenCookieOptions default value to null

### DIFF
--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -183,7 +183,7 @@ export function CentraProvider(props: ProviderProps) {
     receiptPage,
     tokenExpires = 365,
     tokenName = 'centra-checkout-token',
-    tokenCookieOptions = {},
+    tokenCookieOptions = null,
   } = props
 
   const [selection, setSelection] = React.useState<Centra.CheckoutApi.SelectionResponse>(


### PR DESCRIPTION
Set default value to `null` to avoid infinite re-renders when `tokenCookieOptions` are not defined.