### PR TITLE
feature/color-contrast

### DIFF
--- a/packages/utils/src/colorContrast.test.js
+++ b/packages/utils/src/colorContrast.test.js
@@ -1,0 +1,39 @@
+import colorContrast from './colorContrast'
+
+describe('colorContrast', () => {
+  it('is a function and returns an object', () => {
+    expect(typeof colorContrast).toEqual('function')
+    expect(typeof colorContrast('#000', '#fff')).toEqual('object')
+  })
+
+  it('accepts 3-digit hex colors, 6 digit hex colors; with or without #', () => {
+    expect(colorContrast('#000', '#fff').contrastRatio).toEqual(21)
+    expect(colorContrast('#000', 'fff').contrastRatio).toEqual(21)
+    expect(colorContrast('000', '#fff').contrastRatio).toEqual(21)
+    expect(colorContrast('000', 'fff').contrastRatio).toEqual(21)
+    expect(colorContrast('#000000', '#ffffff').contrastRatio).toEqual(21)
+    expect(colorContrast('#000000', 'ffffff').contrastRatio).toEqual(21)
+    expect(colorContrast('000000', '#ffffff').contrastRatio).toEqual(21)
+    expect(colorContrast('000000', 'ffffff').contrastRatio).toEqual(21)
+  })
+
+  it('accepts any number of color arguments', () => {
+    expect(colorContrast('#000', '#fff', '#aaa').contrastRatio).toEqual(21)
+    expect(colorContrast('#000', '#fff', '#aaa', '#bbb').contrastRatio).toEqual(21)
+    expect(colorContrast('#000', '#fff', '#aaa', '#bbb', '#ccc').contrastRatio).toEqual(21)
+  })
+
+  it('returns the correct fallback color', () => {
+    expect(colorContrast('#000', '#aaa').fallbackColor).toEqual('#FFFFFF')
+    expect(colorContrast('#FFF', '#667789').fallbackColor).toEqual('#000000')
+    expect(colorContrast('#FFF', '#74899F').fallbackColor).toEqual('#000000')
+  })
+
+  it('returns correct contrast ratio for arbitrary colors', () => {
+    expect(colorContrast('#000', '#fff').contrastRatio).toEqual(21)
+    expect(colorContrast('#000', '#aaa').contrastRatio).toEqual(9.04)
+    expect(colorContrast('#FFF', '#667789').contrastRatio).toEqual(4.6)
+    expect(colorContrast('#FFF', '#74899F').contrastRatio).toEqual(3.61)
+    expect(colorContrast('#51f', '#821522', '#dde', 'f3a').contrastRatio).toEqual(5.38)
+  })
+})

--- a/packages/utils/src/colorContrast.test.js
+++ b/packages/utils/src/colorContrast.test.js
@@ -3,7 +3,15 @@ import colorContrast from './colorContrast'
 describe('colorContrast', () => {
   it('is a function and returns an object', () => {
     expect(typeof colorContrast).toEqual('function')
+    expect(typeof colorContrast('#000')).toEqual('object')
     expect(typeof colorContrast('#000', '#fff')).toEqual('object')
+  })
+
+  it('handles invalid color arguments', () => {
+    expect(colorContrast()).toEqual({})
+    expect(colorContrast(0, 24, {})).toEqual({})
+    expect(colorContrast(50, [], {})).toEqual({})
+    expect(colorContrast().contrastRatio).toEqual(undefined)
   })
 
   it('accepts 3-digit hex colors, 6 digit hex colors; with or without #', () => {
@@ -23,10 +31,16 @@ describe('colorContrast', () => {
     expect(colorContrast('#000', '#fff', '#aaa', '#bbb', '#ccc').contrastRatio).toEqual(21)
   })
 
-  it('returns the correct fallback color', () => {
-    expect(colorContrast('#000', '#aaa').fallbackColor).toEqual('#FFFFFF')
-    expect(colorContrast('#FFF', '#667789').fallbackColor).toEqual('#000000')
-    expect(colorContrast('#FFF', '#74899F').fallbackColor).toEqual('#000000')
+  it('returns the correct colorAA color', () => {
+    expect(colorContrast('#000', '#aaa').colorAA).toEqual('#aaa')
+    expect(colorContrast('#FFF', '#667789').colorAA).toEqual('#667789')
+    expect(colorContrast('#FFF', '#74899F').colorAA).toEqual('#000')
+  })
+
+  it('returns the correct colorAAA color', () => {
+    expect(colorContrast('#000', '#aaa').colorAAA).toEqual('#aaa')
+    expect(colorContrast('#FFF', '#667789').colorAAA).toEqual('#000')
+    expect(colorContrast('#FFF', '#74899F').colorAAA).toEqual('#000')
   })
 
   it('returns correct contrast ratio for arbitrary colors', () => {

--- a/packages/utils/src/colorContrast.ts
+++ b/packages/utils/src/colorContrast.ts
@@ -1,0 +1,87 @@
+/**
+ * Helper function to calculate relative luminance for a color
+ */
+const calculateLuminance = (rgb: [number, number, number]): number => {
+  const [r, g, b] = rgb.map((c) => {
+    const sRGB = c / 255
+    return sRGB <= 0.03928 ? sRGB / 12.92 : ((sRGB + 0.055) / 1.055) ** 2.4
+  })
+
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+  return luminance
+}
+
+/**
+ * Helper function to calculate contrast ratio between two colors
+ */
+const calculateContrast = (rgb1: [number, number, number], rgb2: [number, number, number]) => {
+  const luminance1 = calculateLuminance(rgb1)
+  const luminance2 = calculateLuminance(rgb2)
+  const contrast =
+    (Math.max(luminance1, luminance2) + 0.05) / (Math.min(luminance1, luminance2) + 0.05)
+  return contrast
+}
+
+/**
+ * Helper function to convert hex to RGB
+ */
+const hexToRGB = (hex: string): [number, number, number] => {
+  let normalizedHex = hex.replace(/^#/, '')
+
+  // Expand shorthand hex notation
+  if (normalizedHex.length === 3) {
+    normalizedHex = normalizedHex
+      .split('')
+      .map((char) => char + char)
+      .join('')
+  }
+
+  const r = parseInt(normalizedHex.substring(0, 2), 16)
+  const g = parseInt(normalizedHex.substring(2, 4), 16)
+  const b = parseInt(normalizedHex.substring(4, 6), 16)
+  return [r, g, b]
+}
+
+/**
+ * Accepts a HEX `baseColor` and any number of HEX `colors`
+ * and returns the color with the highest contrast ratio.
+ *
+ * @example colorContrast('#51f', '#821522', '#dde', 'f3a')
+ * // { contrast: '#dde', contrastRatio: 5.38, fallbackColor: '#fff' }
+ */
+const colorContrast = (baseColor: string, ...colors: string[]) => {
+  // Convert base color to RGB
+  const baseRGB = hexToRGB(baseColor)
+
+  // Find the color with the highest contrast ratio
+  let highestContrastRatio = 0
+
+  let bestContrastingColor = ''
+  let absoluteContrast = ''
+
+  for (let i = 0; i < colors.length; i += 1) {
+    // Convert color to RGB
+    const rgb = hexToRGB(colors[i])
+
+    // Calculate contrast ratio
+    const contrast = calculateContrast(baseRGB, rgb)
+
+    // Update highest contrast color
+    if (contrast > highestContrastRatio) {
+      highestContrastRatio = contrast
+      bestContrastingColor = colors[i]
+    }
+  }
+
+  // Determine the best fallbackColor, being black or white
+  const luminance = calculateLuminance(baseRGB)
+  absoluteContrast = luminance > 0.5 ? '#000' : '#fff'
+
+  return {
+    contrast: bestContrastingColor,
+    contrastRatio: Math.round((highestContrastRatio + Number.EPSILON) * 100) / 100,
+    fallbackColor: absoluteContrast,
+  }
+}
+
+export default colorContrast

--- a/packages/utils/src/colorContrast.ts
+++ b/packages/utils/src/colorContrast.ts
@@ -47,9 +47,14 @@ const hexToRGB = (hex: string): [number, number, number] => {
  * and returns the color with the highest contrast ratio.
  *
  * @example colorContrast('#51f', '#821522', '#dde', 'f3a')
- * // { contrast: '#dde', contrastRatio: 5.38, fallbackColor: '#fff' }
+ * // { contrast: '#dde', contrastRatio: 5.38, colorAA: '#dde', colorAAA: '#fff' }
  */
 const colorContrast = (baseColor: string, ...colors: string[]) => {
+  if (!baseColor || typeof baseColor !== 'string') return {}
+
+  colors = colors.filter((c) => typeof c === 'string')
+  if (!colors.length) return {}
+
   // Convert base color to RGB
   const baseRGB = hexToRGB(baseColor)
 
@@ -80,7 +85,8 @@ const colorContrast = (baseColor: string, ...colors: string[]) => {
   return {
     contrast: bestContrastingColor,
     contrastRatio: Math.round((highestContrastRatio + Number.EPSILON) * 100) / 100,
-    fallbackColor: absoluteContrast,
+    colorAA: highestContrastRatio >= 4.5 ? bestContrastingColor : absoluteContrast,
+    colorAAA: highestContrastRatio >= 7 ? bestContrastingColor : absoluteContrast,
   }
 }
 

--- a/packages/utils/src/colorContrast.ts
+++ b/packages/utils/src/colorContrast.ts
@@ -53,7 +53,6 @@ const colorContrast = (baseColor: string, ...colors: string[]) => {
   if (!baseColor || typeof baseColor !== 'string') return {}
 
   colors = colors.filter((c) => typeof c === 'string')
-  if (!colors.length) return {}
 
   // Convert base color to RGB
   const baseRGB = hexToRGB(baseColor)

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 export { default as clamp } from './clamp'
+export { default as colorContrast } from './colorContrast'
 export { default as lerp } from './lerp'
 export { default as mapRange } from './mapRange'
 export { default as normalize } from './normalize'


### PR DESCRIPTION
Adds a `colorContrast` function, which accepts a HEX `baseColor`, proceeded with any number of HEX `colors` and returns an object containing:

```tsx
contrast: string; // The most contrasting color in the `color` arguments passed
contrastRatio: number; // The contrast ratio for the `contrast` color (the most contrasting color in relation to the `baseColor`)
fallbackColor: string; // Either #000 or #fff, the most appropriate fallback color to use if the `contrastRatio` is not sufficient
```