### PR TITLE
feat: add overridable types and context type narrowing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,18 @@ module.exports = {
         'react/prop-types': 'off',
       },
     },
+    {
+      files: ['packages/centra-types/**/*'],
+      rules: {
+        '@typescript-eslint/ban-types': [
+          'error',
+          {
+            types: { '{}': false },
+            extendDefaults: true,
+          },
+        ],
+        '@typescript-eslint/no-empty-interface': 'off',
+      },
+    },
   ],
 }

--- a/packages/centra-types/models/Product.d.ts
+++ b/packages/centra-types/models/Product.d.ts
@@ -3,8 +3,9 @@ import BundleInfo from './BundleInfo'
 import Item from './Item'
 
 export interface ProductMeasurementChartOverrides {}
-export interface ProductRelatedProductOverrides {}
+export interface ProductMediaObjectsAttributesOverrides {}
 export interface ProductPriceAttributeOverrides {}
+export interface ProductRelatedProductOverrides {}
 
 export default interface Product {
   available?: boolean
@@ -91,7 +92,7 @@ export default interface Product {
     media?: number
     sources?: Record<string, { url?: string }[]>
     // TODO: type this
-    attributes: unknown[]
+    attributes: OverridableObject<unknown[], ProductMediaObjectsAttributesOverrides>
   }[]
   modifiedAt?: string
   // TODO: type this

--- a/packages/centra-types/models/Product.d.ts
+++ b/packages/centra-types/models/Product.d.ts
@@ -1,5 +1,10 @@
+import { OverridableObject, OverridableStringUnion, Prettify } from '../utils'
 import BundleInfo from './BundleInfo'
 import Item from './Item'
+
+export interface ProductMeasurementChartOverrides {}
+export interface ProductRelatedProductOverrides {}
+export interface ProductPriceAttributeOverrides {}
 
 export default interface Product {
   available?: boolean
@@ -90,7 +95,7 @@ export default interface Product {
   }[]
   modifiedAt?: string
   // TODO: type this
-  measurementChart: unknown[]
+  measurementChart: OverridableObject<unknown[], ProductMeasurementChartOverrides>
   createdAt: string
   preview?: boolean
   subscriptionPlans?: {
@@ -110,36 +115,34 @@ export default interface Product {
   relation?: string
 }
 
-export interface RelatedProduct extends Omit<Product, 'relatedProducts'> {
-  relatedProducts?: Pick<Product, 'available' | 'media' | 'product' | 'relation'>[]
-}
+export type RelatedProduct = OverridableObject<
+  Prettify<
+    Omit<Product, 'relatedProducts'> & {
+      relatedProducts?: Pick<Product, 'available' | 'media' | 'product' | 'relation'>[]
+    }
+  >,
+  ProductRelatedProductOverrides
+>
 
-export interface ProductWithPrices
-  extends Omit<
-    Product,
-    | 'price'
-    | 'priceAsNumber'
-    | 'priceBeforeDiscount'
-    | 'priceBeforeDiscountAsNumber'
-    | 'discountPercent'
-    | 'showAsOnSale'
-    | 'showAsNew'
-  > {
-  prices?: Record<
-    string,
-    Pick<
-      Product,
-      | 'price'
-      | 'priceAsNumber'
-      | 'priceBeforeDiscount'
-      | 'priceBeforeDiscountAsNumber'
-      | 'discountPercent'
-      | 'showAsOnSale'
-      | 'showAsNew'
-    >
-  >
-}
+export type ProductPriceAttribute = OverridableStringUnion<
+  | 'price'
+  | 'priceAsNumber'
+  | 'priceBeforeDiscount'
+  | 'priceBeforeDiscountAsNumber'
+  | 'discountPercent'
+  | 'showAsOnSale'
+  | 'showAsNew',
+  ProductPriceAttributeOverrides
+>
 
-export interface ProductWithMarkets extends Product {
-  markets?: number[]
-}
+export type ProductWithPrices = Prettify<
+  Omit<Product, ProductPriceAttribute> & {
+    prices?: Record<string, Pick<Product, ProductPriceAttribute>>
+  }
+>
+
+export type ProductWithMarkets = Prettify<
+  Product & {
+    markets?: number[]
+  }
+>

--- a/packages/centra-types/models/Product.d.ts
+++ b/packages/centra-types/models/Product.d.ts
@@ -95,7 +95,7 @@ export default interface Product {
   }[]
   modifiedAt?: string
   // TODO: type this
-  measurementChart: OverridableObject<unknown[], ProductMeasurementChartOverrides>
+  measurementChart?: OverridableObject<unknown[], ProductMeasurementChartOverrides>
   createdAt: string
   preview?: boolean
   subscriptionPlans?: {
@@ -115,14 +115,9 @@ export default interface Product {
   relation?: string
 }
 
-export type RelatedProduct = OverridableObject<
-  Prettify<
-    Omit<Product, 'relatedProducts'> & {
-      relatedProducts?: Pick<Product, 'available' | 'media' | 'product' | 'relation'>[]
-    }
-  >,
-  ProductRelatedProductOverrides
->
+export type RelatedProduct = Omit<Product, 'relatedProducts'> & {
+  relatedProducts?: Pick<Product, 'available' | 'media' | 'product' | 'relation'>[]
+}
 
 export type ProductPriceAttribute = OverridableStringUnion<
   | 'price'

--- a/packages/centra-types/models/SelectionItem.d.ts
+++ b/packages/centra-types/models/SelectionItem.d.ts
@@ -8,7 +8,7 @@ export default interface SelectionItem {
   size?: string
   sku?: string
   ean?: string
-  quantity?: number
+  quantity: number
   subscriptionPlan?: {
     name?: string
     intervalValue?: number
@@ -54,7 +54,7 @@ export default interface SelectionItem {
     ean?: string
     silkProduct?: string
     silkVariant?: string
-    quantity?: number
+    quantity: number
     comment?: string
     localizedSize?: string | null
     priceEach?: string

--- a/packages/centra-types/utils/index.d.ts
+++ b/packages/centra-types/utils/index.d.ts
@@ -1,0 +1,41 @@
+/**
+ * Return type `U` as long as it's shape is not empty, otherwise return type `T`.
+ */
+export type OverridableObject<T, U extends {}> = keyof U extends never ? T : U
+
+/**
+ * Takes an object type and makes the hover overlay more readable.
+ * @see https://www.totaltypescript.com/concepts/the-prettify-helper
+ */
+export type Prettify<T> = {
+  [K in keyof T]: T[K]
+} & {}
+
+/**
+ * Remove properties `K` from `T`.
+ * Distributive for union types.
+ */
+export type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never
+
+/**
+ * Like `T & U`, but using the value types from `U` where their properties overlap.
+ */
+export type Overwrite<T, U> = DistributiveOmit<T, keyof U> & U
+
+/**
+ * Generate a set of string literal types with the given default record `T` and
+ * override record `U`.
+ *
+ * If the property value was `true`, the property key will be added to the
+ * string union.
+ */
+export type OverridableStringUnion<T extends string | number, U = {}> = GenerateStringUnion<
+  Overwrite<Record<T, true>, U>
+>
+
+type GenerateStringUnion<T> = Extract<
+  {
+    [Key in keyof T]: true extends T[Key] ? Key : never
+  }[keyof T],
+  string
+>

--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -189,8 +189,8 @@ export const SELECTION_INITIAL_VALUE = {
   shippingMethods: [],
 }
 
-export const CentraHandlersContext = React.createContext<ContextMethods>({})
-const CentraSelectionContext = React.createContext<ContextProperties>({})
+export const CentraHandlersContext = React.createContext<ContextMethods | null>(null)
+const CentraSelectionContext = React.createContext<ContextProperties | null>(null)
 
 /** React Context provider that is required to use the `useCentra` and `useCentraHandlers` hooks */
 export function CentraProvider(props: ProviderProps) {
@@ -641,13 +641,37 @@ export function CentraProvider(props: ProviderProps) {
 }
 
 /** This hook returns the centra selection */
-export function useCentraSelection(): ContextProperties {
-  return React.useContext(CentraSelectionContext)
+export function useCentraSelection() {
+  const context = React.useContext(CentraSelectionContext)
+
+  if (context === null) {
+    throw new Error(
+      [
+        '@noaignite/react-centra-checkout: `useCentraSelection` may only be',
+        'used inside the `CentraProvider` react tree, please declare it at a',
+        'higher level.',
+      ].join(' '),
+    )
+  }
+
+  return context
 }
 
 /** This hook returns update handlers */
-export function useCentraHandlers(): ContextMethods {
-  return React.useContext(CentraHandlersContext)
+export function useCentraHandlers() {
+  const context = React.useContext(CentraHandlersContext)
+
+  if (context === null) {
+    throw new Error(
+      [
+        '@noaignite/react-centra-checkout: `useCentraHandlers` may only be',
+        'used inside the `CentraProvider` react tree, please declare it at a',
+        'higher level.',
+      ].join(' '),
+    )
+  }
+
+  return context
 }
 
 /** Returns the latest order receipt given a selection token */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5534,14 +5534,14 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001370:
-  version "1.0.30001457"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz"
-  integrity sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==
+  version "1.0.30001579"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz"
+  integrity sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==
 
 caniuse-lite@^1.0.30001449:
-  version "1.0.30001473"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz#3859898b3cab65fc8905bb923df36ad35058153c"
-  integrity sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==
+  version "1.0.30001579"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz"
+  integrity sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
This PR adds:
* Overridable types to `@noaignite/centra-types`
* Type narrowing for `useCentraSelection` & `useCentraHandlers` in `@noaignite/react-centra-checkout`