### PR TITLE
fix(ci): `type-check` after `build`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "turbo build",
-    "ci": "pnpm run lint && pnpm run test && pnpm run build",
+    "ci": "pnpm run build && pnpm run test",
     "dev": "turbo dev",
     "format": "prettier --write .",
     "lint": "turbo lint",


### PR DESCRIPTION
The CI pipeline currently breaks while running `pnpm run ci` with the following error: 

```bash
Error: app/page.tsx(1,36): error TS2307: Cannot find module '@repo/ui' or its corresponding type declarations.
```

This is caused by the execution order in the `ci` script:

```
pnpm run lint && pnpm run test && pnpm run build
```

We can't run `test` before `build`.
`test` runs `tsc` which requires that all types are accessible in the current package, which never does due to that `pnpm run build` hasn't yet executed.
