### PR TITLE
fix(react-centra-checkout): make CentraCheckout optional

### DIFF
--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -237,14 +237,14 @@ export function CentraProvider(props: ProviderProps) {
         | Promise<CheckoutApi.Response<CheckoutApi.SelectionResponse>>
         | (() => Promise<CheckoutApi.Response<CheckoutApi.SelectionResponse>>),
     ) => {
-      window.CentraCheckout.suspend()
+      window.CentraCheckout?.suspend()
       const response = typeof apiCall === 'function' ? await apiCall() : await apiCall
 
       if ('selection' in response && response.selection) {
         setSelection(response)
       }
 
-      window.CentraCheckout.resume()
+      window.CentraCheckout?.resume()
 
       return response
     },

--- a/packages/react-centra-checkout/src/ShipwalletEmbed/index.tsx
+++ b/packages/react-centra-checkout/src/ShipwalletEmbed/index.tsx
@@ -8,7 +8,7 @@ export default function ShipwalletEmbed() {
   useEffect(() => {
     if ('CentraCheckout' in window) {
       // we need to re init the shipwallet if the centra checkout script was loaded before the ingrid embed
-      window.CentraCheckout.reInitiate('shipwallet')
+      window.CentraCheckout?.reInitiate('shipwallet')
     }
   }, [])
 

--- a/packages/react-centra-checkout/src/types/global.d.ts
+++ b/packages/react-centra-checkout/src/types/global.d.ts
@@ -1,6 +1,6 @@
 interface Window {
   // the interface that the centra checkout scripts adds to window
-  CentraCheckout: {
+  CentraCheckout?: {
     suspend: () => void
     resume: () => void
     reInitiate: (plugin: string) => void


### PR DESCRIPTION
Fixes crash if `window.CentraCheckout` doesn't exist