### PR TITLE
build: revert ci:release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "turbo build",
-    "ci:release": "changeset version && pnpm install && pnpm run build && pnpm run test && changeset publish",
+    "ci:release": "pnpm run build && pnpm run test && changeset publish",
     "ci:test": "pnpm run build && pnpm run test",
     "dev": "turbo dev",
     "format": "prettier --write .",


### PR DESCRIPTION
Revert the `ci:release` script from also executing `changeset version` to test out what the changeset-bot does.