### PR TITLE
build(package.json): add `engines.pnpm: ^9`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "packageManager": "pnpm@9.3.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "pnpm": "^9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "packageManager": "pnpm@9.3.0",
   "engines": {
-    "node": ">=18",
+    "node": ">=20",
     "pnpm": "^9"
   }
 }


### PR DESCRIPTION
Adding this to enforce that the `pnpm` version is atleast 9.
Prior to this, i was able to execute `pnpm install` with version 8.
Enforcing the version won't trigger unwanted changes in
`pnpm-lock.yaml`.
