### PR TITLE
chore(capitalize): use default export and add to barrel file

### DIFF
--- a/packages/utils/src/capitalize.test.js
+++ b/packages/utils/src/capitalize.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { capitalize } from './capitalize'
+import capitalize from './capitalize'
 
 describe('capitalize', () => {
   it('should work', () => {

--- a/packages/utils/src/capitalize.ts
+++ b/packages/utils/src/capitalize.ts
@@ -9,6 +9,6 @@
  * capitalize('hello') // 'Hello'
  * ```
  */
-export function capitalize(str: string): string {
+export default function capitalize(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1)
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
+export { default as capitalize } from './capitalize'
 export { default as clamp } from './clamp'
 export { default as colorContrast } from './colorContrast'
 export { default as lerp } from './lerp'


### PR DESCRIPTION
* Update `capitalize` to use `default` export to follow the same pattern as the rest of the utils. Dropping `default` exports will be a future PR.
* Add `capitalize` to the index barrel file.