### PR TITLE
build(react-utils): drop commonJS support

### DIFF
--- a/.changeset/little-panthers-invite.md
+++ b/.changeset/little-panthers-invite.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-utils': minor
+---
+
+drop support for commonJS

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -19,9 +19,16 @@
   "license": "MIT",
   "author": "NoA Ignite",
   "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.mts"
+    },
+    "./*": {
+      "import": "./dist/*.mjs",
+      "types": "./dist/*.d.mts"
+    }
+  },
   "files": [
     "dist/**"
   ],

--- a/packages/react-utils/tsup.config.ts
+++ b/packages/react-utils/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/**/*.{ts,tsx}'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   bundle: false, // NOTE: Disable `bundle` as this causes issues with the 'use client' directive.
   clean: true,
   dts: true,


### PR DESCRIPTION
# Background
To my surprise I noticed that when consuming this package in a NextJS project the `next build` script fails for the `createRenderBlock` function meanwhile `next dev` works just fine. I'm still not entirely sure what the issue is, but I can get `next build` to succeed if I skip the `commonJS` build and only build `esm` modules.

# Changes
I discussed this with @adamsoderstrom and went ahead and dropped the support for `commonJS` for this package as this package is after all meant to be consumed in an `esm` environment. Furthermore, stable `esm` support has been in `node` since version 14 and latest node version is currently at 22. Additionally it's easier to debug the built files as the `dist` folder is less bloated.