### PR TITLE
hotfix/remove-centra-checkout-callback-suspend

### DIFF
--- a/.changeset/seven-socks-help.md
+++ b/.changeset/seven-socks-help.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-centra-checkout': patch
+---
+
+Removes invalid call to CentraCheckout.suspend, fixes PaymentEmbed not rendering

--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -259,6 +259,10 @@ export function CentraProvider(props: ProviderProps) {
         event.detail,
       )) as CheckoutApi.Response<CheckoutApi.SelectionResponse>
 
+      if ('selection' in response && response.selection) {
+        setSelection(response)
+      }
+
       window.CentraCheckout?.resume(event.detail.additionalFields?.suspendIgnore)
 
       centraEvents.dispatch('centra_checkout_callback', response)

--- a/packages/react-centra-checkout/src/Context/index.tsx
+++ b/packages/react-centra-checkout/src/Context/index.tsx
@@ -252,17 +252,18 @@ export function CentraProvider(props: ProviderProps) {
   )
 
   const centraCheckoutCallback = useCallback(
-    async (event: CustomEvent) => {
-      if (event.detail) {
-        const response = await selectionApiCall(
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- TODO: Fix this
-          apiClient.request('PUT', `payment-fields`, event.detail),
-        )
+    async (event: CustomEvent<CentraCheckoutEventDetails>) => {
+      const response = (await apiClient.request(
+        'PUT',
+        `payment-fields`,
+        event.detail,
+      )) as CheckoutApi.Response<CheckoutApi.SelectionResponse>
 
-        centraEvents.dispatch('centra_checkout_callback', response)
-      }
+      window.CentraCheckout?.resume(event.detail.additionalFields?.suspendIgnore)
+
+      centraEvents.dispatch('centra_checkout_callback', response)
     },
-    [apiClient, selectionApiCall],
+    [apiClient],
   )
 
   const init = useCallback<NonNullable<ContextMethods['init']>>(

--- a/packages/react-centra-checkout/src/PaymentEmbed/index.tsx
+++ b/packages/react-centra-checkout/src/PaymentEmbed/index.tsx
@@ -93,7 +93,8 @@ const PaymentEmbed = memo(function PaymentEmbed(
   // Retrieve formHtml
   useEffect(() => {
     const shouldRequestPayment =
-      paymentMethod?.supportsInitiateOnly ?? paymentMethod?.providesCustomerAddressAfterPayment // if either of these are true, this is a paymentMethod which provides an embed
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- we actually want || here because we are checking for undefined, null and false
+      paymentMethod?.supportsInitiateOnly || paymentMethod?.providesCustomerAddressAfterPayment // if either of these are true, this is a paymentMethod which provides an embed
 
     if (
       ((selection?.paymentMethod === previousPaymentMethod.current || !shouldRequestPayment) &&

--- a/packages/react-centra-checkout/src/types/global.d.ts
+++ b/packages/react-centra-checkout/src/types/global.d.ts
@@ -1,8 +1,16 @@
 interface Window {
   // the interface that the centra checkout scripts adds to window
   CentraCheckout?: {
-    suspend: () => void
-    resume: () => void
+    suspend: (suspendIgnore?: Record<string, unknown>) => void
+    resume: (suspendIgnore?: Record<string, unknown>) => void
     reInitiate: (plugin: string) => void
   }
+}
+
+interface CentraCheckoutEventDetails {
+  additionalFields?: {
+    event: string
+    suspendIgnore: Record<string, boolean>
+  }
+  [key: string]: unknown
 }


### PR DESCRIPTION
This fixes an issue we are having on a client project where `CentraCheckout.suspend()` is called after clicking the submit payment button in Klarna. This is apparently not supposed to be called according to [these](https://centra.dev/docs/tools/scripts/centra-checkoutscript#suspend-and-resume) docs.

Also fixes an unintentional bug in PaymentEmbed causing it not to render.