### PR TITLE
feat(react-hooks): add new `react-hooks` package

### DIFF
--- a/packages/react-hooks/.eslintrc.cjs
+++ b/packages/react-hooks/.eslintrc.cjs
@@ -1,0 +1,4 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  extends: ['@repo/eslint-config/react.js'],
+}

--- a/packages/react-hooks/LICENSE
+++ b/packages/react-hooks/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 NoA Ignite
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -1,0 +1,18 @@
+# @noaignite/react-hooks
+
+React hooks - Utility functions for React.
+
+## Installation
+
+React hooks is available as an [npm package](https://www.npmjs.com/package/@noaignite/react-hooks).
+
+```sh
+// with pnpm
+pnpm install @noaignite/react-hooks
+
+// with npm
+npm install @noaignite/react-hooks
+
+// with yarn
+yarn add @noaignite/react-hooks
+```

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@noaignite/react-hooks",
+  "version": "0.0.0",
+  "private": false,
+  "description": "React hooks",
+  "keywords": [
+    "react",
+    "react-hooks",
+    "typescript"
+  ],
+  "bugs": {
+    "url": "https://github.com/noaignite/accelerator/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/noaignite/accelerator.git",
+    "directory": "packages/react-hooks"
+  },
+  "license": "MIT",
+  "author": "NoA Ignite",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.mts"
+    },
+    "./*": {
+      "import": "./dist/*.mjs",
+      "types": "./dist/*.d.mts"
+    }
+  },
+  "files": [
+    "dist/**"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "eslint src/ --ignore-pattern '**/*.test.js'",
+    "test-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^20.14.2",
+    "@types/react": "^18.2.65",
+    "react": "^18.2.0",
+    "tsup": "^8.0.1",
+    "typescript": "5.4.5"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -43,6 +43,7 @@
     "@repo/typescript-config": "workspace:*",
     "@types/node": "^20.14.2",
     "@types/react": "^18.2.65",
+    "esbuild-plugin-preserve-directives": "0.0.9",
     "react": "^18.2.0",
     "tsup": "^8.0.1",
     "typescript": "5.4.5"

--- a/packages/react-hooks/tsconfig.json
+++ b/packages/react-hooks/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@repo/typescript-config/react-library.json",
+  "include": ["."],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/react-hooks/tsup.config.ts
+++ b/packages/react-hooks/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/**/*.{ts,tsx}'],
+  format: ['esm'],
+  bundle: false, // NOTE: Disable `bundle` as this causes issues with the 'use client' directive.
+  clean: true,
+  dts: true,
+  minify: true,
+  sourcemap: true,
+})

--- a/packages/react-hooks/tsup.config.ts
+++ b/packages/react-hooks/tsup.config.ts
@@ -1,11 +1,20 @@
+// @ts-expect-error - TODO: Create PR & remove `type: "module"` at https://github.com/Seojunhwan/esbuild-plugin-preserve-directives
+import { preserveDirectivesPlugin } from 'esbuild-plugin-preserve-directives'
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/**/*.{ts,tsx}'],
   format: ['esm'],
-  bundle: false, // NOTE: Disable `bundle` as this causes issues with the 'use client' directive.
   clean: true,
   dts: true,
   minify: true,
   sourcemap: true,
+  esbuildPlugins: [
+    preserveDirectivesPlugin({
+      directives: ['use client', 'use strict'],
+      // eslint-disable-next-line prefer-named-capture-group -- Is this a necessary rule?
+      include: /\.(js|ts|jsx|tsx)$/,
+      exclude: /node_modules/,
+    }),
+  ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,16 +162,19 @@ importers:
         version: link:../typescript-config
       '@types/node':
         specifier: ^20.14.2
-        version: 20.14.2
+        version: 20.14.15
       '@types/react':
         specifier: ^18.2.65
         version: 18.2.75
+      esbuild-plugin-preserve-directives:
+        specifier: 0.0.9
+        version: 0.0.9(esbuild@0.23.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
       tsup:
         specifier: ^8.0.1
-        version: 8.1.0(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))(typescript@5.4.5)
+        version: 8.1.2(jiti@1.21.6)(postcss@8.4.38)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
         specifier: 5.4.5
         version: 5.4.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,30 @@ importers:
         specifier: 5.4.5
         version: 5.4.5
 
+  packages/react-hooks:
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^20.14.2
+        version: 20.14.2
+      '@types/react':
+        specifier: ^18.2.65
+        version: 18.2.75
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      tsup:
+        specifier: ^8.0.1
+        version: 8.1.0(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))(typescript@5.4.5)
+      typescript:
+        specifier: 5.4.5
+        version: 5.4.5
+
   packages/react-utils:
     dependencies:
       react-dom:


### PR DESCRIPTION
Created an empty scaffold for a new `react-hooks` package where we can start gathering useful hooks we want to publish.