### PR TITLE
chore(react-centra-checkout): update `@noaignite/*` package versions

### DIFF
--- a/packages/react-centra-checkout/package.json
+++ b/packages/react-centra-checkout/package.json
@@ -37,7 +37,7 @@
     "js-cookie": "^3.0.1"
   },
   "devDependencies": {
-    "@noaignite/centra-types": "^1.2.0",
+    "@noaignite/centra-types": "workspace:*",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/js-cookie": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         version: 3.2.2
     devDependencies:
       '@noaignite/centra-types':
-        specifier: ^1.2.0
+        specifier: workspace:*
         version: link:../centra-types
       '@repo/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
Update `@noaignite/*` dependency versions to `workspace:*` instead of fixed numbers as `pnpm publish` (done by Github Actions) will make sure to swap these out to the latest version upon publishing.

NOTE: No changeset needed.