### PR TITLE
build(utils): bump typescript from 4.7.4 to 5.4.5

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,7 +33,7 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "tsup": "^8.1.2",
-    "typescript": "^4.7.4",
+    "typescript": "5.4.5",
     "vitest": "^2.0.5"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,10 +222,10 @@ importers:
         version: link:../typescript-config
       tsup:
         specifier: ^8.1.2
-        version: 8.1.2(jiti@1.21.6)(postcss@8.4.38)(typescript@4.9.5)(yaml@2.5.0)
+        version: 8.1.2(jiti@1.21.6)(postcss@8.4.38)(typescript@5.4.5)(yaml@2.5.0)
       typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
+        specifier: 5.4.5
+        version: 5.4.5
       vitest:
         specifier: ^2.0.5
         version: 2.0.5(@types/node@20.14.15)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0)
@@ -3428,11 +3428,6 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: 4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x
-
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
 
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
@@ -7336,32 +7331,6 @@ snapshots:
 
   tslib@2.6.3: {}
 
-  tsup@8.1.2(jiti@1.21.6)(postcss@8.4.38)(typescript@4.9.5)(yaml@2.5.0):
-    dependencies:
-      bundle-require: 5.0.0(esbuild@0.23.1)
-      cac: 6.7.14
-      chokidar: 3.6.0
-      consola: 3.2.3
-      debug: 4.3.6
-      esbuild: 0.23.1
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.38)(yaml@2.5.0)
-      resolve-from: 5.0.0
-      rollup: 4.21.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.4.38
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
   tsup@8.1.2(jiti@1.21.6)(postcss@8.4.38)(typescript@5.4.5)(yaml@2.5.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
@@ -7470,8 +7439,6 @@ snapshots:
       minimatch: 5.1.6
       shiki: 0.10.1
       typescript: 5.4.5
-
-  typescript@4.9.5: {}
 
   typescript@5.4.5: {}
 


### PR DESCRIPTION
Bump `typescript` to version 5.4.5 matching the rest of the updated accelerator packages. Version 5.4.5 and not higher due to `@vercel/style-guide` typescript/eslint requirements.