### PR TITLE
fix/react utils/bundle true

### DIFF
--- a/.changeset/swift-papayas-grin.md
+++ b/.changeset/swift-papayas-grin.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-utils': patch
+---
+
+re-enable tsup bundle setting thanks to esbuild-plugin-preserve-directives plugin

--- a/packages/react-utils/package.json
+++ b/packages/react-utils/package.json
@@ -39,6 +39,7 @@
     "test-types": "tsc --noEmit"
   },
   "devDependencies": {
+    "@adamsoderstrom/esbuild-plugin-preserve-directives": "0.0.10",
     "@noaignite/types": "workspace:^",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/packages/react-utils/tsup.config.ts
+++ b/packages/react-utils/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   esbuildPlugins: [
     preserveDirectivesPlugin({
       directives: ['use client', 'use strict'],
+      // eslint-disable-next-line prefer-named-capture-group -- Is this a necessary rule?
       include: /\.(js|ts|jsx|tsx)$/,
       exclude: /node_modules/,
     }),

--- a/packages/react-utils/tsup.config.ts
+++ b/packages/react-utils/tsup.config.ts
@@ -1,11 +1,19 @@
+import { preserveDirectivesPlugin } from '@adamsoderstrom/esbuild-plugin-preserve-directives'
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/**/*.{ts,tsx}'],
   format: ['esm'],
-  bundle: false, // NOTE: Disable `bundle` as this causes issues with the 'use client' directive.
+  bundle: true,
   clean: true,
   dts: true,
   minify: true,
   sourcemap: true,
+  esbuildPlugins: [
+    preserveDirectivesPlugin({
+      directives: ['use client', 'use strict'],
+      include: /\.(js|ts|jsx|tsx)$/,
+      exclude: /node_modules/,
+    }),
+  ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         version: 7.8.0(typescript@5.4.5)
       '@vercel/style-guide':
         specifier: 6.0.0
-        version: 6.0.0(@next/eslint-plugin-next@14.2.4)(eslint@8.57.0)(prettier@3.3.3)(typescript@5.4.5)(vitest@2.0.5)
+        version: 6.0.0(@next/eslint-plugin-next@14.2.4)(eslint@8.57.0)(prettier@3.3.3)(typescript@5.4.5)(vitest@2.0.5(@types/node@20.14.2)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0))
       eslint:
         specifier: 8.57.0
         version: 8.57.0
@@ -79,7 +79,7 @@ importers:
     devDependencies:
       '@vercel/style-guide':
         specifier: 6.0.0
-        version: 6.0.0(@next/eslint-plugin-next@14.2.4)(eslint@9.5.0)(prettier@3.3.3)(typescript@5.4.5)(vitest@2.0.5)
+        version: 6.0.0(@next/eslint-plugin-next@14.2.4)(eslint@9.5.0)(prettier@3.3.3)(typescript@5.4.5)(vitest@2.0.5(@types/node@20.14.2)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0))
       prettier:
         specifier: 3.3.3
         version: 3.3.3
@@ -139,6 +139,9 @@ importers:
         specifier: ^18.0.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@adamsoderstrom/esbuild-plugin-preserve-directives':
+        specifier: 0.0.10
+        version: 0.0.10(esbuild@0.23.1)
       '@noaignite/types':
         specifier: workspace:^
         version: link:../types
@@ -174,7 +177,7 @@ importers:
         version: link:../typescript-config
       tailwindcss:
         specifier: ^3.4.1
-        version: 3.4.9(ts-node@10.9.2(typescript@5.4.5))
+        version: 3.4.9(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
       tsup:
         specifier: ^8.1.2
         version: 8.1.2(jiti@1.21.6)(postcss@8.4.38)(typescript@5.4.5)(yaml@2.4.5)
@@ -221,6 +224,12 @@ importers:
         version: 2.0.5(@types/node@20.14.2)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0)
 
 packages:
+
+  '@adamsoderstrom/esbuild-plugin-preserve-directives@0.0.10':
+    resolution: {integrity: sha512-LTuC89Ba+azBKwIi12dcGGsu/UjVj8L2ollj1sc0tK1bVVf3K0O0TvohCYiIYwqkSSv0kIIdPxHk4abSMlvPrA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      esbuild: ^0.21.0
 
   '@adobe/css-tools@4.3.3':
     resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
@@ -3499,6 +3508,10 @@ packages:
 
 snapshots:
 
+  '@adamsoderstrom/esbuild-plugin-preserve-directives@0.0.10(esbuild@0.23.1)':
+    dependencies:
+      esbuild: 0.23.1
+
   '@adobe/css-tools@4.3.3':
     optional: true
 
@@ -4491,7 +4504,7 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vercel/style-guide@6.0.0(@next/eslint-plugin-next@14.2.4)(eslint@8.57.0)(prettier@3.3.3)(typescript@5.4.5)(vitest@2.0.5)':
+  '@vercel/style-guide@6.0.0(@next/eslint-plugin-next@14.2.4)(eslint@8.57.0)(prettier@3.3.3)(typescript@5.4.5)(vitest@2.0.5(@types/node@20.14.2)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/eslint-parser': 7.24.7(@babel/core@7.24.7)(eslint@8.57.0)
@@ -4511,7 +4524,7 @@ snapshots:
       eslint-plugin-testing-library: 6.2.2(eslint@8.57.0)(typescript@5.4.5)
       eslint-plugin-tsdoc: 0.2.17
       eslint-plugin-unicorn: 51.0.1(eslint@8.57.0)
-      eslint-plugin-vitest: 0.3.26(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)(vitest@2.0.5)
+      eslint-plugin-vitest: 0.3.26(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)(vitest@2.0.5(@types/node@20.14.2)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0))
       prettier-plugin-packagejson: 2.5.0(prettier@3.3.3)
     optionalDependencies:
       '@next/eslint-plugin-next': 14.2.4
@@ -4525,7 +4538,7 @@ snapshots:
       - supports-color
       - vitest
 
-  '@vercel/style-guide@6.0.0(@next/eslint-plugin-next@14.2.4)(eslint@9.5.0)(prettier@3.3.3)(typescript@5.4.5)(vitest@2.0.5)':
+  '@vercel/style-guide@6.0.0(@next/eslint-plugin-next@14.2.4)(eslint@9.5.0)(prettier@3.3.3)(typescript@5.4.5)(vitest@2.0.5(@types/node@20.14.2)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/eslint-parser': 7.24.7(@babel/core@7.24.7)(eslint@9.5.0)
@@ -4545,7 +4558,7 @@ snapshots:
       eslint-plugin-testing-library: 6.2.2(eslint@9.5.0)(typescript@5.4.5)
       eslint-plugin-tsdoc: 0.2.17
       eslint-plugin-unicorn: 51.0.1(eslint@9.5.0)
-      eslint-plugin-vitest: 0.3.26(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.7.1(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5)(vitest@2.0.5)
+      eslint-plugin-vitest: 0.3.26(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.7.1(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5)(vitest@2.0.5(@types/node@20.14.2)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0))
       prettier-plugin-packagejson: 2.5.0(prettier@3.3.3)
     optionalDependencies:
       '@next/eslint-plugin-next': 14.2.4
@@ -5495,7 +5508,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)(vitest@2.0.5):
+  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)(vitest@2.0.5(@types/node@20.14.2)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0)):
     dependencies:
       '@typescript-eslint/utils': 7.13.0(eslint@8.57.0)(typescript@5.4.5)
       eslint: 8.57.0
@@ -5506,7 +5519,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.7.1(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5)(vitest@2.0.5):
+  eslint-plugin-vitest@0.3.26(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.7.1(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5))(eslint@9.5.0)(typescript@5.4.5)(vitest@2.0.5(@types/node@20.14.2)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.6)(stylus@0.62.0)):
     dependencies:
       '@typescript-eslint/utils': 7.13.0(eslint@9.5.0)(typescript@5.4.5)
       eslint: 9.5.0
@@ -6552,13 +6565,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.38
 
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(typescript@5.4.5)):
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.4.38
-      ts-node: 10.9.2(typescript@5.4.5)
+      ts-node: 10.9.2(@types/node@20.14.2)(typescript@5.4.5)
 
   postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.38)(yaml@2.4.5):
     dependencies:
@@ -7012,7 +7025,7 @@ snapshots:
       '@pkgr/core': 0.1.1
       tslib: 2.6.3
 
-  tailwindcss@3.4.9(ts-node@10.9.2(typescript@5.4.5)):
+  tailwindcss@3.4.9(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -7031,7 +7044,7 @@ snapshots:
       postcss: 8.4.38
       postcss-import: 15.1.0(postcss@8.4.38)
       postcss-js: 4.0.1(postcss@8.4.38)
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(typescript@5.4.5))
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5))
       postcss-nested: 6.2.0(postcss@8.4.38)
       postcss-selector-parser: 6.1.1
       resolve: 1.22.8
@@ -7083,13 +7096,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(typescript@5.4.5):
+  ts-node@10.9.2(@types/node@20.14.2)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.2
       acorn: 8.12.1
       acorn-walk: 8.3.3
       arg: 4.1.3


### PR DESCRIPTION
Prior to this commit, we've had an issue where directives like `"use
client"` gets stripped out of the `chunk-*` files created in the `dist`
folder, when specifying `bundle: true` in `tsup.config.ts`.
I tried to trace this issue and found a corresponding one in the `esbuild` repo (0).
In that, i found that @Seojunhwan had created a ESBuild plugin (1) that
resolves this issue. Though, as of this writing, the plugin doesn't
support single-quote directives, which we have in our repository. I
forked the repo and submitted a PR for that (2). Until then, i've
published my fix under my personal namespace and use it here.

[0]: https://github.com/evanw/esbuild/issues/3115
[1]: https://github.com/Seojunhwan/esbuild-plugin-preserve-directives
[2]: https://github.com/Seojunhwan/esbuild-plugin-preserve-directives/pull/15