### PR TITLE
build(centra-types, react-centra-checkout): bump typescript from 4.7.4 to 5.4.5

### DIFF
--- a/packages/centra-types/package.json
+++ b/packages/centra-types/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "typedoc": "^0.22.9",
-    "typescript": "^4.7.4"
+    "typescript": "5.4.5"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/react-centra-checkout/package.json
+++ b/packages/react-centra-checkout/package.json
@@ -45,7 +45,7 @@
     "@types/react": "^17.0.35",
     "tsup": "^8.1.2",
     "typedoc": "^0.22.9",
-    "typescript": "^4.7.4"
+    "typescript": "5.4.5"
   },
   "peerDependencies": {
     "react": "^17.0.0 || ^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,10 +37,10 @@ importers:
         version: link:../typescript-config
       typedoc:
         specifier: ^0.22.9
-        version: 0.22.18(typescript@4.9.5)
+        version: 0.22.18(typescript@5.4.5)
       typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
+        specifier: 5.4.5
+        version: 5.4.5
 
   packages/create-app:
     dependencies:
@@ -131,13 +131,13 @@ importers:
         version: 17.0.80
       tsup:
         specifier: ^8.1.2
-        version: 8.1.2(jiti@1.21.6)(postcss@8.4.38)(typescript@4.9.5)(yaml@2.5.0)
+        version: 8.1.2(jiti@1.21.6)(postcss@8.4.38)(typescript@5.4.5)(yaml@2.5.0)
       typedoc:
         specifier: ^0.22.9
-        version: 0.22.18(typescript@4.9.5)
+        version: 0.22.18(typescript@5.4.5)
       typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
+        specifier: 5.4.5
+        version: 5.4.5
 
   packages/react-utils:
     dependencies:
@@ -4622,7 +4622,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 7.8.0(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/parser': 7.7.1(eslint@8.57.0)(typescript@5.4.5)
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0))
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0))
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
@@ -5307,7 +5307,7 @@ snapshots:
       eslint: 8.57.0
       eslint-plugin-turbo: 2.0.14(eslint@8.57.0)
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)):
     dependencies:
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.1(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
 
@@ -7462,14 +7462,14 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typedoc@0.22.18(typescript@4.9.5):
+  typedoc@0.22.18(typescript@5.4.5):
     dependencies:
       glob: 8.1.0
       lunr: 2.3.9
       marked: 4.3.0
       minimatch: 5.1.6
       shiki: 0.10.1
-      typescript: 4.9.5
+      typescript: 5.4.5
 
   typescript@4.9.5: {}
 


### PR DESCRIPTION
Bump `typescript` to version 5.4.5 matching the rest of the updated accelerator packages. Version 5.4.5 and not higher due to `@vercel/style-guide` typescript/eslint requirements. Included both these packages as `centra-types` is as dependency to `react-centra-checkout`.

NOTE: No changeset needed