### PR TITLE
feat(centra-types, react-centra-checkout): bump minimum engine node version from 14 to 20

### DIFF
--- a/.changeset/great-zoos-cover.md
+++ b/.changeset/great-zoos-cover.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-centra-checkout': major
+---
+
+bump minimum engine node version from 14 to 20

--- a/.changeset/rude-wombats-peel.md
+++ b/.changeset/rude-wombats-peel.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/centra-types': major
+---
+
+bump minimum engine node version from 14 to 20

--- a/packages/centra-types/package.json
+++ b/packages/centra-types/package.json
@@ -30,7 +30,7 @@
     "typescript": "^4.7.4"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/react-centra-checkout/package.json
+++ b/packages/react-centra-checkout/package.json
@@ -53,7 +53,7 @@
     "react-fast-compare": "^3.2.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
BREAKING CHANGE