### PR TITLE
chore(changeset): changeset no longer commits for you + add changeset section to CONTRIBUTING.md

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": true,
+  "commit": false,
   "fixed": [],
   "linked": [],
   "access": "restricted",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,16 @@ git push
 
 4. Go to [the repository](https://github.com/noaignite/accelerator) and make a Pull Request.
 
+## Adding a changeset to your Pull Request
+
+Not all Pull Requests need a changeset. Adding a changeset to your Pull Request will cause a version bump for the specified packages. If your changes should not result in a new version, no changeset is needed. When creating a changeset, make sure to include the generated changeset in the same commit as the corresponding code changes.
+
+Create a changeset:
+
+```sh
+pnpm changeset
+```
+
 <!--
 ### Trying the changes on the documentation site
 


### PR DESCRIPTION
As stated in ticket #249. Update changeset config to not commit. The idea is for the created changeset to be part of the same commit that implements the feature so that the linked commit in the CHANGELOG actually has all the related code.
