### PR TITLE
feat(create-app/tailwind-config): add separate exported config for typography

### DIFF
--- a/.changeset/big-impalas-raise.md
+++ b/.changeset/big-impalas-raise.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/create-app': minor
+---
+
+tailwind-config - add separate exported config for typography

--- a/packages/create-app/template-tailwind-config/tailwind.config.ts
+++ b/packages/create-app/template-tailwind-config/tailwind.config.ts
@@ -1,11 +1,8 @@
-import { typography } from '@noaignite/tailwind-typography'
+import { typography as tailwindTypography } from '@noaignite/tailwind-typography'
 import type { Config } from 'tailwindcss'
 import { breakpoints } from './breakpoints'
 import { palette } from './palette'
-import { pxToRem } from './utils'
-
-const fontPrimary = 'var(--font-primary)'
-const fontSecondary = 'var(--font-secondary)'
+import { typography } from './typography'
 
 const config: Config = {
   content: [
@@ -17,8 +14,8 @@ const config: Config = {
   darkMode: ['class', '[data-color-scheme="dark"]'],
   theme: {
     fontFamily: {
-      primary: fontPrimary,
-      secondary: fontSecondary,
+      primary: 'var(--font-primary)',
+      secondary: 'var(--font-secondary)',
     },
     screens: {
       // Generate the system breakpoints.
@@ -60,34 +57,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [
-    typography({
-      breakpointKeys: breakpoints.keys,
-      prefix: 'type-',
-      unit: 'rem',
-      fluid: true,
-      clamp: true,
-      variants: {
-        h1: {
-          xs: {
-            fontFamily: fontPrimary,
-            fontSize: pxToRem(48),
-            fontWeight: 700,
-            letterSpacing: 0,
-            lineHeight: 1.2,
-            textTransform: 'uppercase',
-          },
-          md: { fontSize: pxToRem(72) },
-        },
-        body1: {
-          fontFamily: fontSecondary,
-          fontSize: pxToRem(14),
-          fontWeight: 400,
-          lineHeight: 1.2,
-        },
-      },
-    }),
-  ],
+  plugins: [tailwindTypography(typography)],
 }
 
 export default config

--- a/packages/create-app/template-tailwind-config/typography.ts
+++ b/packages/create-app/template-tailwind-config/typography.ts
@@ -1,0 +1,27 @@
+import type { TypographyOptions } from '@noaignite/tailwind-typography'
+import { breakpoints } from './breakpoints'
+import { pxToRem } from './utils'
+
+export const typography = {
+  breakpointKeys: breakpoints.keys,
+  prefix: 'type-' as const,
+  unit: 'rem',
+  variants: {
+    h1: {
+      xs: {
+        fontFamily: 'var(--font-primary)',
+        fontSize: pxToRem(48),
+        fontWeight: 700,
+        lineHeight: 1.2,
+        textTransform: 'uppercase',
+      },
+      md: { fontSize: pxToRem(72) },
+    },
+    body1: {
+      fontFamily: 'var(--font-secondary)',
+      fontSize: pxToRem(14),
+      fontWeight: 400,
+      lineHeight: 1.2,
+    },
+  },
+} satisfies TypographyOptions<typeof breakpoints.keys>


### PR DESCRIPTION
Having it's own exported file for the typographic config is use if one would want to import it elsewhere. For example to create a Storybook page.