### PR TITLE
ci(changeset): ensure existence of changeset in PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.sha}}
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,18 @@ git push
 
 ## Adding a changeset to your Pull Request
 
-Not all Pull Requests need a changeset. Adding a changeset to your Pull Request will cause a version bump for the specified packages. If your changes should not result in a new version, no changeset is needed. When creating a changeset, make sure to include the generated changeset in the same commit as the corresponding code changes.
+Not all Pull Requests need a changeset. Adding a changeset to your Pull Request will cause a version bump for the specified packages. If your changes should not result in a new version, mark your PR with an empty changeset. When creating a changeset, make sure to include the generated changeset in the same commit as the corresponding code changes.
 
 Create a changeset:
 
 ```sh
 pnpm changeset
+```
+
+Create an empty changeset:
+
+```sh
+pnpm changeset --empty
 ```
 
 <!--
@@ -58,4 +64,4 @@ You can now access the documentation site [locally](http://localhost:3000).
  -->
 
 Where possible, please add tests for any changes you make.
-Tests can be run with `pnpm test`.
+Tests can be run locally with `pnpm test`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "turbo build",
     "ci:release": "pnpm run build && pnpm run test && changeset publish",
-    "ci:test": "pnpm run build && pnpm run test",
+    "ci:test": "changeset status --since=origin/main && pnpm run build && pnpm run test",
     "dev": "turbo dev",
     "docs:build": "pnpm --filter docs run build",
     "docs:build:markdown": "pnpm --filter docs run build:markdown",


### PR DESCRIPTION
Tested locally by applying the changes on an ongoing PR (fails, due to lacking changeset, as it should).
I also tested it how it performs on the `main` branch by applying temporarily there as well (doesn't fail, due to being `main`).

Adding the `changeset status` call to be last in the script improves DX by seeing that the CI pipeline passes before you've necessarily submitted a changeset.
