### PR TITLE
feat(react-utils): pass `blockType` to block, `context` always as object & export new types

### DIFF
--- a/.changeset/nice-beers-kneel.md
+++ b/.changeset/nice-beers-kneel.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-utils': minor
+---
+
+createRenderBlock - `blockType` is now passed to block component

--- a/.changeset/strange-boxes-fail.md
+++ b/.changeset/strange-boxes-fail.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-utils': minor
+---
+
+createRenderBlock - adapter `context` argument (prev `additionalData`) is now always an object

--- a/.changeset/young-suns-beam.md
+++ b/.changeset/young-suns-beam.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-utils': minor
+---
+
+createRenderBlock - export new `BlockTypeMap` & `BlockAdapter` types


### PR DESCRIPTION
- `blockType` is now passed to block component.
- Adapter argument `additionalData` has been renamed to `context`
- Adapter argument `context` is now always an object containing `index` & additional keys one provides to the renderer.
- Export new `BlockTypeMap` & `BlockAdapter` types.