### PR TITLE
fix(react-utils): add missing `'use client'` directive

### DIFF
--- a/.changeset/big-beds-mate.md
+++ b/.changeset/big-beds-mate.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-utils': patch
+---
+
+Add missing 'use client' directive

--- a/packages/react-utils/src/createRenderBlock.test.tsx
+++ b/packages/react-utils/src/createRenderBlock.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- Allow for test files */
-import '@testing-library/jest-dom' // for toBeInTheDocument, etc.
 import { render, screen, waitFor } from '@testing-library/react'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import type { BlockAdapter } from './createRenderBlock'

--- a/packages/react-utils/src/createSvgIcon.test.tsx
+++ b/packages/react-utils/src/createSvgIcon.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { describe, expect, it } from 'vitest'

--- a/packages/react-utils/src/setRef.ts
+++ b/packages/react-utils/src/setRef.ts
@@ -1,3 +1,5 @@
+import type { RefObject } from 'react'
+
 /**
  * Useful if you want to expose the ref of an inner component to the public API
  * while still using it inside the component.
@@ -5,7 +7,7 @@
  * @param ref - A ref callback or ref object. If anything falsy, this is a no-op.
  */
 export function setRef<T>(
-  ref: React.MutableRefObject<T | null> | ((instance: T | null) => void) | null | undefined,
+  ref: RefObject<T | null> | ((instance: T | null) => void) | null | undefined,
   value: T | null,
 ): void {
   if (typeof ref === 'function') {

--- a/packages/react-utils/src/useEvent.ts
+++ b/packages/react-utils/src/useEvent.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { assert } from '@noaignite/utils'
 import type { RefObject } from 'react'
 import { useEffect, useRef } from 'react'

--- a/packages/react-utils/src/useFocusReturn.ts
+++ b/packages/react-utils/src/useFocusReturn.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import type { RefObject } from 'react'
 import { useIsomorphicEffect } from './useIsomorphicEffect'
 

--- a/packages/react-utils/src/useInert.ts
+++ b/packages/react-utils/src/useInert.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import type { HintedString } from '@noaignite/types'
 import type { RefObject } from 'react'
 import { useIsomorphicEffect } from './useIsomorphicEffect'

--- a/packages/react-utils/src/useIsomorphicEffect.ts
+++ b/packages/react-utils/src/useIsomorphicEffect.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useEffect, useLayoutEffect } from 'react'
 
 /**

--- a/packages/react-utils/src/useSticky.ts
+++ b/packages/react-utils/src/useSticky.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { assert } from '@noaignite/utils'
 import { useCallback, useEffect, useState, type RefObject } from 'react'
 import { useIntersectionObserver } from './useIntersectionObserver'


### PR DESCRIPTION
* fix(react-utils): add missing 'use client' directive
* test(react-utils): remove unnecessary imports
* chore(react-utils/setRef): change out deprecated MutableRefObject