### PR TITLE
fix(style-guide): add `node.js` ESlint config 

### DIFF
--- a/.changeset/loud-cougars-clap.md
+++ b/.changeset/loud-cougars-clap.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/style-guide': patch
+---
+
+fix(style-guide): add `node.js` ESlint config

--- a/packages/style-guide/eslint/base.js
+++ b/packages/style-guide/eslint/base.js
@@ -4,6 +4,7 @@ import es6Config from './rules/es6.js'
 import ignoresConfig from './rules/ignores.js'
 import importConfig from './rules/import.js'
 import javascriptConfig from './rules/javascript.js'
+import nodeConfig from './rules/node.js'
 import possibleErrorsConfig from './rules/possible-errors.js'
 import prettierConfig from './rules/prettier.js'
 import stylisticConfig from './rules/stylistic.js'
@@ -20,6 +21,7 @@ import vitestConfig from './rules/vitest.js'
 export default [
   ...ignoresConfig,
   ...javascriptConfig,
+  ...nodeConfig,
   ...prettierConfig,
   ...typescriptConfig,
   ...bestPracticeConfig,

--- a/packages/style-guide/eslint/rules/node.js
+++ b/packages/style-guide/eslint/rules/node.js
@@ -1,0 +1,12 @@
+import globals from 'globals'
+
+export default [
+  {
+    name: '@noaignite/style-guide/node',
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+]


### PR DESCRIPTION
# Why?

- Global variables like `__dirname` and `process.env.` are otherwise not recognized.
- The [`eslint-config-next`](https://github.com/vercel/next.js/blob/21d2a32d50164f877917c6c79dfc0e6686a5bb59/packages/eslint-config-next/index.js#L125-L128) package already adds it