### PR TITLE
fix(react-centra-checkout): unable to call method on base class

### DIFF
--- a/.changeset/lazy-areas-allow.md
+++ b/.changeset/lazy-areas-allow.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-centra-checkout': patch
+---
+
+Resolve TS2340 error while trying to call `super.request` from sub class

--- a/packages/react-centra-checkout/src/ApiClient.ts
+++ b/packages/react-centra-checkout/src/ApiClient.ts
@@ -17,7 +17,7 @@ export class ApiClient {
     })
   }
 
-  request = async (method: string, endpoint: string, data: Record<string, unknown> = {}) => {
+  async request(method: string, endpoint: string, data: Record<string, unknown> = {}) {
     const response = await fetch(`${this.baseUrl}/${endpoint}`, {
       ...this.options,
       headers: this.headers,


### PR DESCRIPTION
Tried to extend the `ApiClient` class, while i receieved a `TS2340`
error from TypeScript. Defining the `request` property as a method (and
not a function) resolves that error.

Related sources for solution:
- https://stackoverflow.com/questions/55422250/typescript-cannot-call-super-method-on-child-class
- https://codereviewvideos.com/how-i-fixed-ts2340-only-public-and-protected-methods-of-the-base-class-are-accessible-via-the-super-keyword/