### PR TITLE
fix(create-app): `storybook-static` output folder is not ignored

### DIFF
--- a/.changeset/young-stars-divide.md
+++ b/.changeset/young-stars-divide.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/create-app': patch
+---
+
+Add `storybook-static` to `.gitignore`

--- a/packages/create-app/template-docs/.gitignore
+++ b/packages/create-app/template-docs/.gitignore
@@ -1,0 +1,1 @@
+storybook-static


### PR DESCRIPTION
`storybook-static` is considered a dist / build directory, outputted by
the `build` script. Think we can `gitignore` it.
