### PR TITLE
feat(react-utils): add the observer as the secondary callback arg

### DIFF
--- a/.changeset/good-lamps-speak.md
+++ b/.changeset/good-lamps-speak.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-utils': minor
+---
+
+Add the observer as the secondary callback arg

--- a/packages/react-utils/src/useIntersectionObserver.test.ts
+++ b/packages/react-utils/src/useIntersectionObserver.test.ts
@@ -33,7 +33,7 @@ describe('useIntersectionObserver', () => {
       observer?.trigger([fakeEntry])
     })
 
-    expect(callback).toHaveBeenCalledWith(fakeEntry)
+    expect(callback).toHaveBeenCalledWith(fakeEntry, observer)
   })
 
   it('does not observe when `when` is false', () => {
@@ -114,7 +114,7 @@ describe('useIntersectionObserver', () => {
     rerender({ cb: callback2 })
     act(() => observer?.trigger([fakeEntry]))
     expect(callback1).toHaveBeenCalledTimes(1)
-    expect(callback2).toHaveBeenCalledWith(fakeEntry)
+    expect(callback2).toHaveBeenCalledWith(fakeEntry, observer)
   })
 
   it('passes correct options to IntersectionObserver constructor', async () => {

--- a/packages/react-utils/src/useIntersectionObserver.ts
+++ b/packages/react-utils/src/useIntersectionObserver.ts
@@ -4,7 +4,10 @@ import type { RefObject } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useIsomorphicEffect } from './useIsomorphicEffect'
 
-export type UseIntersectionObserverCallback = (entry: IntersectionObserverEntry) => void
+export type UseIntersectionObserverCallback = (
+  entry: IntersectionObserverEntry,
+  observer: IntersectionObserver,
+) => void
 
 export type IntersectionObserverOptions = IntersectionObserverInit & {
   /**
@@ -60,11 +63,9 @@ export const useIntersectionObserver = (
     if (!(element instanceof Element)) return
 
     const observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0]
+      ([entry], observer) => {
         if (!entry) return
-
-        savedCallback.current(entry)
+        savedCallback.current(entry, observer)
         setIsTerminated(Boolean(entry.isIntersecting && once))
       },
       { root, rootMargin, threshold },


### PR DESCRIPTION
Closer to the native `IntersectionObserver` API callback. Reaching for the internal observer can be helpful.