### PR TITLE
fix(react-utils/createPolymorph): allow components to set `displayName`

### DIFF
--- a/.changeset/clear-geese-name.md
+++ b/.changeset/clear-geese-name.md
@@ -1,0 +1,5 @@
+---
+'@noaignite/react-utils': patch
+---
+
+createPolymorph: Expose and initialize `displayName` for created components.

--- a/packages/react-utils/src/createPolymorph.test.tsx
+++ b/packages/react-utils/src/createPolymorph.test.tsx
@@ -56,6 +56,37 @@ describe('createPolymorph', () => {
     expect(createPolymorph(testFunction)).toBe(testFunction)
   })
 
+  it('sets the display name from the render function', async () => {
+    const { createPolymorph } = await import('./createPolymorph')
+
+    const render: PolymorphicRenderFunction<object, 'button'> = () => null
+    const Button = createPolymorph(render)
+
+    expect(Button.displayName).toBe('render')
+  })
+
+  it('uses a fallback display name for anonymous render functions', async () => {
+    const { createPolymorph } = await import('./createPolymorph')
+
+    const render: PolymorphicRenderFunction<object, 'button'> = () => null
+    Object.defineProperty(render, 'name', { value: '' })
+
+    const Button = createPolymorph(render)
+
+    expect(Button.displayName).toBe('PolymorphicComponent')
+  })
+
+  it('preserves an existing display name', async () => {
+    const { createPolymorph } = await import('./createPolymorph')
+
+    const render: PolymorphicRenderFunction<object, 'button'> = () => null
+    render.displayName = 'CustomButton'
+
+    const Button = createPolymorph(render)
+
+    expect(Button.displayName).toBe('CustomButton')
+  })
+
   it('treats a bare `object` props definition as having no custom keys', async () => {
     const { createPolymorph } = await import('./createPolymorph')
 

--- a/packages/react-utils/src/createPolymorph.ts
+++ b/packages/react-utils/src/createPolymorph.ts
@@ -188,9 +188,10 @@ export type PolymorphicRenderFunction<
   P extends Props,
   T extends ElementType = ElementType,
   C extends Exact<Config<P, T>, C> = object,
-> = (
-  props: PolymorphicProps<P, T, C>,
-) => PolymorphicElement<P, T> | Promise<PolymorphicElement<P, T>>
+> = {
+  displayName?: string;
+  (props: PolymorphicProps<P, T, C>): PolymorphicElement<P, T> | Promise<PolymorphicElement<P, T>>
+}
 
 /**
  * Return type of `createPolymorph`.
@@ -203,11 +204,14 @@ export type PolymorphicExoticComponent<
   P extends Props,
   T extends ElementType = AsOrDefault<P, ElementType>,
   C extends Exact<Config<P, T>, C> = object,
-> = <TT = AsOrDefault<P, T>>(
-  props: PolymorphicProps<P, TT extends ElementType ? TT : T, C>,
-) =>
-  | PolymorphicElement<P, TT extends ElementType ? TT : T>
-  | Promise<PolymorphicElement<P, TT extends ElementType ? TT : T>>
+> = {
+  displayName?: string;
+  <TT = AsOrDefault<P, T>>(
+    props: PolymorphicProps<P, TT extends ElementType ? TT : T, C>,
+  ):
+    | PolymorphicElement<P, TT extends ElementType ? TT : T>
+    | Promise<PolymorphicElement<P, TT extends ElementType ? TT : T>>
+}
 
 /**
  * Creates a polymorphic component.
@@ -262,6 +266,8 @@ export const createPolymorph = <
     (Number(version.split('.')[0]) || 0) >= 19,
     'To use `createPolymorph`, please upgrade "react" and "@types/react" to version 19 or higher.',
   )
+
+  render.displayName ??= render.name || 'PolymorphicComponent'
 
   return render as PolymorphicExoticComponent<P, T, C>
 }


### PR DESCRIPTION
`createPolymorph` returns the original render function at runtime, so React components created by it can already have `displayName` assigned. Its TypeScript return type only described the callable signature, however, valid assignments such as `Button.displayName = 'Button'` to fail type checking. This change exposes the optional property in the public type and adds regression coverage.